### PR TITLE
Fix temperature conversion formula bugs

### DIFF
--- a/buggy_temperature.py
+++ b/buggy_temperature.py
@@ -1,0 +1,12 @@
+def celsius_to_fahrenheit(celsius):
+    # Bug fixed: correct formula C * 9/5 + 32
+    fahrenheit = celsius * 9/5 + 32
+    return fahrenheit
+
+def fahrenheit_to_celsius(fahrenheit):
+    # Bug fixed: correct order of operations (F - 32) * 5/9
+    celsius = (fahrenheit - 32) * 5/9
+    return celsius
+
+print(f"100°C = {celsius_to_fahrenheit(100)}°F")
+print(f"212°F = {fahrenheit_to_celsius(212)}°C")


### PR DESCRIPTION
Fixed both celsius_to_fahrenheit and fahrenheit_to_celsius functions with correct mathematical formulas: C to F: C * 9/5 + 32, F to C: (F - 32) * 5/9. Added proper parentheses for order of operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added temperature conversion capability between Celsius and Fahrenheit, supporting conversions in both directions using standard formulas.
  * Running the module prints sample conversion outputs for quick verification.
  * Note: No input validation or error handling is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->