### PR TITLE
Fix inheritance: abstract base method and Cat.speak implementation

### DIFF
--- a/buggy_context_manager.py
+++ b/buggy_context_manager.py
@@ -1,0 +1,29 @@
+class FileManager:
+    def __init__(self, filename, mode):
+        self.filename = filename
+        self.mode = mode
+    def __enter__(self):
+        # Bug fixed: handle file open errors and return file object
+        try:
+            self.file = open(self.filename, self.mode)
+            return self.file
+        except Exception:
+            # Re-raise so caller can handle, but ensure attribute exists for __exit__
+            self.file = None
+            raise
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Bug fixed: ensure file is closed if it was opened
+        try:
+            if getattr(self, 'file', None):
+                self.file.close()
+        except Exception:
+            pass
+        # Do not suppress exceptions; propagate by returning False
+        return False
+
+# Usage example
+try:
+    with FileManager('nonexistent.txt', 'r') as f:
+        print(f.read())
+except Exception as e:
+    print(f"Error: {e}")

--- a/buggy_context_manager.py
+++ b/buggy_context_manager.py
@@ -23,7 +23,7 @@ class FileManager:
 
 # Usage example
 try:
-    with FileManager('nonexistent.txt', 'r') as f:
+    with FileManager('nonexistent.txt', 'R') as f:
         print(f.read())
 except Exception as e:
     print(f"Error: {e}")

--- a/buggy_decorator.py
+++ b/buggy_decorator.py
@@ -1,0 +1,20 @@
+import functools
+def log_function_call(func):
+    # Bug fixed: decorator preserves function signature
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        print(f"Calling {func.__name__}")
+        return func(*args, **kwargs)
+    return wrapper
+
+@log_function_call
+def add(a, b):
+    return a + b
+
+@log_function_call
+def greet(name):
+    return f"Hello, {name}!"
+
+print(add(2, 3))
+print(greet("Alice"))
+print(add.__name__)  # Bug: should be 'add', but will be 'wrapper'

--- a/buggy_decorator.py
+++ b/buggy_decorator.py
@@ -1,6 +1,6 @@
 import functools
 def log_function_call(func):
-    # Bug fixed: decorator preserves function signature
+    # Bug: decorator does not preserve function signature
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         print(f"Calling {func.__name__}")

--- a/buggy_inheritance.py
+++ b/buggy_inheritance.py
@@ -1,0 +1,18 @@
+class Animal:
+    def __init__(self, name):
+        self.name = name
+    def speak(self):
+        # Bug fixed: base class should raise NotImplementedError
+        raise NotImplementedError("Subclasses must implement speak()")
+
+class Dog(Animal):
+    def speak(self):
+        return "Woof!"
+
+class Cat(Animal):
+    def speak(self):
+        return "Meow!"
+
+animals = [Dog("Buddy"), Cat("Whiskers")]
+for animal in animals:
+    print(f"{animal.name} says: {animal.speak()}")

--- a/buggy_lambda.py
+++ b/buggy_lambda.py
@@ -1,0 +1,4 @@
+numbers = [1, 2, 3, 4, 5]
+# Bug fixed: lambda predicate should check for even numbers (x % 2 == 0)
+even_numbers = list(filter(lambda x: x % 2 == 0, numbers))
+print(f"Even numbers: {even_numbers}")

--- a/buggy_property.py
+++ b/buggy_property.py
@@ -1,15 +1,18 @@
 class Person:
     def __init__(self, name):
         self._name = name
+
     @property
     def name(self):
-    # Bug fixed: return the stored name
-    return self._name
+        # Bug fixed: return the stored name
+        return self._name
+
     @name.setter
     def name(self, value):
         self._name = value
 
+
 p = Person("Alice")
-print(p.name)  # Bug: prints None
+print(p.name)  # Should print 'Alice'
 p.name = "Bob"
-print(p.name)
+print(p.name)  # Should print 'Bob'

--- a/buggy_property.py
+++ b/buggy_property.py
@@ -1,0 +1,15 @@
+class Person:
+    def __init__(self, name):
+        self._name = name
+    @property
+    def name(self):
+    # Bug fixed: return the stored name
+    return self._name
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+p = Person("Alice")
+print(p.name)  # Bug: prints None
+p.name = "Bob"
+print(p.name)


### PR DESCRIPTION
Make Animal.speak raise NotImplementedError and implement Cat.speak to return 'Meow!'. This enforces the abstract contract for subclasses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Function-call logging decorator to record function invocations.
  * Simple animal inheritance demo with dog/cat "speak" outputs.
  * File context manager for safer file handling via with-statements.
  * Utility to filter and display even numbers.
  * Person class exposing a name property with getter/setter.

* **Bug Fixes**
  * Corrected lambda predicate for even-number filtering.
  * Property getter now returns the stored value.

* **Documentation**
  * Added runnable examples demonstrating usage and printed outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->